### PR TITLE
Install gpio-shutdown dtoverlay

### DIFF
--- a/playbook.yaml
+++ b/playbook.yaml
@@ -82,6 +82,17 @@
             script: "{{ rpi_services_dir }}/templogger.py --period {{ temp_meas_period }}",
           }
 
+    - name: "Setup GPIO Shutdown overlay"
+      blockinfile:
+        block: |
+          [all]
+          # Enable GPIO shutdown
+          dtoverlay=gpio-shutdown,active_low,gpiopin={{ gpio_shutdown.pin }}
+        append_newline: yes
+        insertafter: EOF
+        path: /boot/firmware/config.txt
+      when: gpio_shutdown.enabled
+
     - name: "Setup Python virtual environment"
       import_role:
         name: python_venv

--- a/vars/config_common.yml
+++ b/vars/config_common.yml
@@ -1,2 +1,6 @@
 ---
 install_dir: /opt/rpi
+
+gpio_shutdown:
+  enabled: yes
+  pin: 3


### PR DESCRIPTION
Add the gpio-shutdown overlay to `/boot/firmware/config.txt` so that the RPi can be shutdown by pressing a button on the HAT.